### PR TITLE
Final version of uncorrelated cut and add the pre_process.py

### DIFF
--- a/run3/flow/BDT/compute_frac_cut_var.py
+++ b/run3/flow/BDT/compute_frac_cut_var.py
@@ -11,6 +11,8 @@ from ROOT import kBlack, kRed, kAzure, kGreen, kRainBow # pylint: disable=import
 from ROOT import kFullCircle, kFullSquare, kOpenSquare, kOpenCircle, kOpenCross, kOpenDiamond # pylint: disable=import-error,no-name-in-module
 from os.path import exists
 sys.path.append('../../../')
+sys.path.append('..')
+from flow_analysis_utils import get_cut_sets_config
 from utils.StyleFormatter import SetGlobalStyle, SetObjectStyle
 from utils.AnalysisUtils import GetPromptFDYieldsAnalyticMinimisation, ApplyVariationToList
 
@@ -37,13 +39,16 @@ def compute_frac_cut_var(config, inputdir, outputdir, suffix, batch=False):
     rawYieldFiles.sort()
 
     # load configuration
+    ptmins = config['ptmins']
+    ptmaxs = config['ptmaxs']
+    
     #TODO: apply smearing
 
     histoNameRaw = config['histoNameRaw']
     histoNameEffPrompt = config['histoNameEffPrompt']
     histoNameEffFD = config['histoNameEffFD']
 
-    nSets = len(rawYieldFiles)
+    # nSets = len(rawYieldFiles)
 
     #TODO: apply smearing
     doRawYieldsSmearing = config['minimisation']['doRawYieldSmearing']
@@ -55,6 +60,9 @@ def compute_frac_cut_var(config, inputdir, outputdir, suffix, batch=False):
     applyEffVarToFD = config['minimisation']['applyEffVariation']['feeddown']
 
     hRawYields, hEffPrompt, hEffFD = [], [], []
+    
+    CutSets, _, _, _, _ = get_cut_sets_config(config)
+    nCutSets = max(CutSets)
 
     # load inputs raw yields and efficiencies
     hCrossSecPrompt, hCrossSecFD = [], []
@@ -134,16 +142,15 @@ def compute_frac_cut_var(config, inputdir, outputdir, suffix, batch=False):
             fNfdNpromptUpper = []
             fNfdNpromptLower = []
 
-    for iPt in range(hRawYields[0].GetNbinsX()):
-        ptMin = hRawYields[0].GetBinLowEdge(iPt+1)
-        ptMax = ptMin + hRawYields[0].GetBinWidth(iPt+1)
+    for iPt, (ptMin, ptMax) in enumerate(zip(ptmins, ptmaxs)):
+        nSets = CutSets[iPt]
 
-        listRawYield = [hRaw.GetBinContent(iPt+1) for hRaw in hRawYields]
-        listRawYieldUnc = [hRaw.GetBinError(iPt+1) for hRaw in hRawYields]
-        listEffPrompt = [hEffP.GetBinContent(iPt+1) for hEffP in hEffPrompt]
-        listEffPromptUnc = [hEffP.GetBinError(iPt+1) for hEffP in hEffPrompt]
-        listEffFD = [hEffF.GetBinContent(iPt+1) for hEffF in hEffFD]
-        listEffFDUnc = [hEffF.GetBinError(iPt+1) for hEffF in hEffFD]
+        listRawYield = [hRaw.GetBinContent(iPt+1) for hRaw in hRawYields[:nSets]]
+        listRawYieldUnc = [hRaw.GetBinError(iPt+1) for hRaw in hRawYields[:nSets]]
+        listEffPrompt = [hEffP.GetBinContent(iPt+1) for hEffP in hEffPrompt[:nSets]]
+        listEffPromptUnc = [hEffP.GetBinError(iPt+1) for hEffP in hEffPrompt[:nSets]]
+        listEffFD = [hEffF.GetBinContent(iPt+1) for hEffF in hEffFD[:nSets]]
+        listEffFDUnc = [hEffF.GetBinError(iPt+1) for hEffF in hEffFD[:nSets]]
 
         if config['linearplot']['enable']:
             fNfdNprompt.append([])

--- a/run3/flow/BDT/cut_variation.py
+++ b/run3/flow/BDT/cut_variation.py
@@ -10,7 +10,7 @@ import os
 import sys
 from alive_progress import alive_bar
 sys.path.append('..')
-from flow_analysis_utils import get_vn_versus_mass, get_centrality_bins, get_cut_sets
+from flow_analysis_utils import get_vn_versus_mass, get_centrality_bins, get_cut_sets_config
 
 def cut_var(config, an_res_file, centrality, resolution, outputdir, suffix):
     with open(config, 'r') as ymlCfgFile:
@@ -28,13 +28,6 @@ def cut_var(config, an_res_file, centrality, resolution, outputdir, suffix):
     inv_mass_bins = config['inv_mass_bins']
     axis_bdt_bkg = config['axes']['bdt_bkg']
     axis_bdt_sig = config['axes']['bdt_sig']
-    bkg_cut_mins = config['cut_variation']['bdt_cut']['bkg']['min']
-    bkg_cut_maxs = config['cut_variation']['bdt_cut']['bkg']['max']
-    bkg_cut_steps = config['cut_variation']['bdt_cut']['bkg']['step']
-    sig_cut_mins = config['cut_variation']['bdt_cut']['sig']['min']
-    sig_cut_maxs = config['cut_variation']['bdt_cut']['sig']['max']
-    sig_cut_steps = config['cut_variation']['bdt_cut']['sig']['step']
-    correlated_cuts = config['minimisation']['correlated']
 
     # get resolution
     resoFile = ROOT.TFile(resolution, 'READ')
@@ -44,15 +37,10 @@ def cut_var(config, an_res_file, centrality, resolution, outputdir, suffix):
     reso = histo_reso.GetBinContent(1)
 
     thnsparse_list, thnsparse_selcent_list, thnsparse_selcents = [], [], []
-    if len(an_res_file) == 0:
-        infile = ROOT.TFile(an_res_file[0], 'READ')
+    for file in an_res_file:
+        infile = ROOT.TFile(file, 'READ')
         thnsparse_list.append(infile.Get('hf-task-flow-charm-hadrons/hSparseFlowCharm'))
         print(infile.GetName())
-    else:
-        for file in an_res_file:
-            infile = ROOT.TFile(file, 'READ')
-            thnsparse_list.append(infile.Get('hf-task-flow-charm-hadrons/hSparseFlowCharm'))
-            print(infile.GetName())
 
     cent_min = cent_bins[0]
     cent_max = cent_bins[1]
@@ -62,11 +50,8 @@ def cut_var(config, an_res_file, centrality, resolution, outputdir, suffix):
 
     os.makedirs(f'{outputdir}/proj', exist_ok=True)
 
-    nCutSets, sig_cut_lower, sig_cut_upper, bkg_cut_lower, bkg_cut_upper = get_cut_sets(pt_mins, pt_maxs, 
-                                                                                    sig_cut_mins, sig_cut_maxs, 
-                                                                                    sig_cut_steps, bkg_cut_mins, 
-                                                                                    bkg_cut_maxs, bkg_cut_steps, 
-                                                                                    correlated_cuts)
+    CutSets, sig_cut_lower, sig_cut_upper, bkg_cut_lower, bkg_cut_upper = get_cut_sets_config(config)
+    nCutSets = max(CutSets)
 
     with alive_bar(nCutSets, title='Processing BDT cuts') as bar:
         for iCut in range(nCutSets):

--- a/run3/flow/BDT/cut_variation.py
+++ b/run3/flow/BDT/cut_variation.py
@@ -110,38 +110,6 @@ sig BDT cut: {sig_cut_lower[ipt][iCut]} - {sig_cut_upper[ipt][iCut]}
                     
                     hist_fd.Add(hist_fd_temp)
                     hist_mass.Add(hist_mass_temp)
-                    
-        #                 for iThn, thnSparse in enumerate(thnSparses):
-        # hist_vn_proj_temp = thnSparse.Projection(vn_axis, mass_axis)
-        # hist_vn_proj_temp.SetName(f'hist_vn_proj_{iThn}')
-        # hist_vn_proj_temp.SetDirectory(0)
-        
-        # if hist_vn_proj is None:
-        #     # 初始化 hist_vn_proj
-        #     hist_vn_proj = hist_vn_proj_temp.Clone('hist_vn_proj')
-        #     hist_vn_proj.Reset()
-        # hist_vn_proj.Add(hist_vn_proj_temp)
-                    
-#                     if iThn == 0:
-#                         hist_fd = thnsparse_selcent.Projection(axis_bdt_sig)
-#                         hist_fd.SetName(f'hist_fd_cent{cent_min}_{cent_max}_pt{pt_min}_{pt_max}')
-#                         hist_fd.SetDirectory(0)
-                        
-#                         thnsparse_selcent.GetAxis(axis_bdt_sig).SetRangeUser(sig_cut_lower[ipt][iCut], sig_cut_upper[ipt][iCut])
-#                         print(f'''pT range: {pt_min} - {pt_max};
-# bkg BDT cut: {bkg_cut_lower[ipt][iCut]} - {bkg_cut_upper[ipt][iCut]};
-# sig BDT cut: {sig_cut_lower[ipt][iCut]} - {sig_cut_upper[ipt][iCut]}
-# ''')
-#                         hist_mass = thnsparse_selcent.Projection(axis_mass)
-#                         hist_mass.SetName(f'hist_mass_cent{cent_min}_{cent_max}_pt{pt_min}_{pt_max}')
-#                         hist_mass.SetDirectory(0)
-#                     else:
-#                         hist_fd_temp = thnsparse_selcent.Projection(axis_bdt_sig)
-#                         hist_fd_temp.SetName(f'hist_fd_cent{cent_min}_{cent_max}_pt{pt_min}_{pt_max}_{iThn}')
-#                         hist_mass_temp = thnsparse_selcent.Projection(axis_mass)
-#                         hist_mass_temp.SetName(f'hist_mass_cent{cent_min}_{cent_max}_pt{pt_min}_{pt_max}_{iThn}')
-#                         hist_fd.Add(thnsparse_selcent.Projection(axis_bdt_sig))
-#                         hist_mass.Add(thnsparse_selcent.Projection(axis_mass))
                         
                     thnsparse_selcents.append(thnsparse_selcent)
 

--- a/run3/flow/BDT/make_yaml_for_ml.py
+++ b/run3/flow/BDT/make_yaml_for_ml.py
@@ -9,7 +9,7 @@ import os
 import numpy as np
 import sys
 sys.path.append('..')
-from flow_analysis_utils import get_cut_sets
+from flow_analysis_utils import get_cut_sets_config
 
 def make_combination(mass_axis, pt_axis, bkg_axis, sig_axis, ptmins, ptmaxs, nCutSets,
                      sig_cut_lower_file, sig_cut_upper_file, bkg_cut_lower_file, bkg_cut_upper_file):
@@ -87,32 +87,30 @@ def make_yaml(flow_config, outputdir, suffix):
     ptmins = input['ptmins']
     ptmaxs = input['ptmaxs']
 
-    # cut variation
-    bkg_cut_mins = input['cut_variation']['bdt_cut']['bkg']['min']
-    bkg_cut_maxs = input['cut_variation']['bdt_cut']['bkg']['max']
-    bkg_cut_steps = input['cut_variation']['bdt_cut']['bkg']['step']
-    sig_cut_mins = input['cut_variation']['bdt_cut']['sig']['min']
-    sig_cut_maxs = input['cut_variation']['bdt_cut']['sig']['max']
-    sig_cut_steps = input['cut_variation']['bdt_cut']['sig']['step']
-
     ## safely check
     if len(ptmins) != len(ptmaxs):
-        raise ValueError(f'''The number of pt bins({len(ptmins)}, {len(ptmaxs)}),
-                         bkg cuts({len(bkg_cut_mins)}, {len(bkg_cut_maxs)}),
-                         and sig cuts({len(sig_cut_mins)}, {len(sig_cut_maxs)}) are not the same''')
+        raise ValueError(f'''The number of pt bins({len(ptmins)}, {len(ptmaxs)} are not the same''')
 
-    nCutSets, sig_cut_lower, sig_cut_upper, bkg_cut_lower, bkg_cut_upper = get_cut_sets(ptmins, ptmaxs, 
-                                                                                        sig_cut_mins, sig_cut_maxs, 
-                                                                                        sig_cut_steps, bkg_cut_mins, 
-                                                                                        bkg_cut_maxs, bkg_cut_steps, 
-                                                                                        input['minimisation']['correlated'])
+    nCutSets, sig_cut_lower, sig_cut_upper, bkg_cut_lower, bkg_cut_upper = get_cut_sets_config(flow_config)
+    
+    maxCutSets = max(nCutSets)
+    sig_cut_lower_file, sig_cut_upper_file, bkg_cut_lower_file, bkg_cut_upper_file = {}, {}, {}, {}
+    for iCut in range(maxCutSets):
+        sig_cut_lower_file[iCut], sig_cut_upper_file[iCut], bkg_cut_lower_file[iCut], bkg_cut_upper_file[iCut] = [], [], [], []
+        for iPt in range(len(ptmins)):
+            # consider the different number of cutsets for each pt bin
+            if iCut < nCutSets[iPt]:
+                sig_cut_lower_file[iCut].append(sig_cut_lower[iPt][iCut])
+                sig_cut_upper_file[iCut].append(sig_cut_upper[iPt][iCut])
+                bkg_cut_lower_file[iCut].append(bkg_cut_lower[iPt][iCut])
+                bkg_cut_upper_file[iCut].append(bkg_cut_upper[iPt][iCut])
+            else:
+                sig_cut_lower_file[iCut].append(sig_cut_lower[iPt][nCutSets[iPt]-1])
+                sig_cut_upper_file[iCut].append(sig_cut_upper[iPt][nCutSets[iPt]-1])
+                bkg_cut_lower_file[iCut].append(bkg_cut_lower[iPt][nCutSets[iPt]-1])
+                bkg_cut_upper_file[iCut].append(bkg_cut_upper[iPt][nCutSets[iPt]-1])
 
-    sig_cut_lower_file = {i: [sig_cut_lower[ipt][i] for ipt in range(len(ptmins))] for i in range(nCutSets)}
-    sig_cut_upper_file = {i: [sig_cut_upper[ipt][i] for ipt in range(len(ptmins))] for i in range(nCutSets)}
-    bkg_cut_lower_file = {i: [bkg_cut_lower[ipt][i] for ipt in range(len(ptmins))] for i in range(nCutSets)}
-    bkg_cut_upper_file = {i: [bkg_cut_upper[ipt][i] for ipt in range(len(ptmins))] for i in range(nCutSets)}
-
-    combinations = make_combination(mass_axis, pt_axis, bkg_axis, sig_axis, ptmins, ptmaxs, nCutSets,
+    combinations = make_combination(mass_axis, pt_axis, bkg_axis, sig_axis, ptmins, ptmaxs, maxCutSets,
                                     sig_cut_lower_file, sig_cut_upper_file, bkg_cut_lower_file, bkg_cut_upper_file)
 
     print(f'''
@@ -121,7 +119,7 @@ The axis number for the pt is {pt_axis}
 The axis number for the bkg output is {bkg_axis}
 The axis number for the signal output is {sig_axis}
 ''')
-    for iFile in range(nCutSets):
+    for iFile in range(maxCutSets):
         print(f'''For cutset {iFile}:
         ptmin: {ptmins}
         ptmax: {ptmaxs}
@@ -132,10 +130,11 @@ The axis number for the signal output is {sig_axis}
 ''')
 
     os.makedirs(f'{outputdir}/config', exist_ok=True)
-    for iFile in range(nCutSets):
+    for iFile in range(maxCutSets):
         with open(f'{outputdir}/config/cutset_{suffix}_{iFile:02}.yml', 'w') as file:
             yaml.dump(combinations[iFile], file, default_flow_style=False)
     print(f'Yaml files are saved in {outputdir}/config')
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Arguments')
     parser.add_argument('flow_config', metavar='text', default='config_flow.yml')

--- a/run3/flow/BDT/run_cutvar.py
+++ b/run3/flow/BDT/run_cutvar.py
@@ -5,7 +5,7 @@ import argparse
 import yaml
 import shutil
 sys.path.append('..')
-from flow_analysis_utils import get_cut_sets
+from flow_analysis_utils import get_cut_sets_config
 
 def check_dir(dir):
 
@@ -32,22 +32,11 @@ def run_full_cut_variation(config_flow, anres_dir, cent, res_file, output, suffi
 
 #___________________________________________________________________________________________________________________________
 	# Load and copy the configuration file
-	with open(config_flow, 'r') as cfgFlow:
-		config = yaml.safe_load(cfgFlow)
-
-	ptmins = config['ptmins']
-	ptmaxs = config['ptmaxs']
-
-	correlated_cuts = config['minimisation']['correlated']
-
-	sig_cut_mins = config['cut_variation']['bdt_cut']['sig']['min']
-	sig_cut_maxs = config['cut_variation']['bdt_cut']['sig']['max']
-	sig_cut_steps = config['cut_variation']['bdt_cut']['sig']['step']
-	bkg_cut_mins = config['cut_variation']['bdt_cut']['bkg']['min']
-	bkg_cut_maxs = config['cut_variation']['bdt_cut']['bkg']['max']
-	bkg_cut_steps = config['cut_variation']['bdt_cut']['bkg']['step']
+	# with open(config_flow, 'r') as cfgFlow:
+	# 	config = yaml.safe_load(cfgFlow)
 	
-	nCutSets, _, _, _, _ = get_cut_sets(ptmins, ptmaxs, sig_cut_mins, sig_cut_maxs, sig_cut_steps, bkg_cut_mins, bkg_cut_maxs, bkg_cut_steps, correlated_cuts)
+	CutSets, _, _, _, _ = get_cut_sets_config(config_flow)
+	nCutSets = max(CutSets)
 
 	print(f"\033[32mNumber of cutsets: {nCutSets}\033[0m")
 

--- a/run3/flow/BDT/run_cutvar.sh
+++ b/run3/flow/BDT/run_cutvar.sh
@@ -21,7 +21,7 @@
 #----------
 
 # export config_flow="/home/wuct/ALICE/local/DmesonAnalysis/run3/flow/config_flow.yml"
-export config_flow="/home/wuct/ALICE/local/Results/BDT/goldenRun/uncorrelated/cutvar_pt2_3/config_flow_pt2_3_18.yml"
+export config_flow="/home/wuct/ALICE/local/DmesonAnalysis/run3/flow/config_flow.yml"
 export anres_dir="/media/wuct/wulby/ALICE/AnRes/D0_flow/pass4/ML/Results/324130/temp_merged_s2_0.root \
     /media/wuct/wulby/ALICE/AnRes/D0_flow/pass4/ML/Results/324130/temp_merged_s2_1.root \
     /media/wuct/wulby/ALICE/AnRes/D0_flow/pass4/ML/Results/324130/temp_merged_s2_2.root \
@@ -33,15 +33,15 @@ export vn_method="sp"
 export res_file="/media/wuct/wulby/ALICE/AnRes/resolution/output_reso/resospk3050_inte.root"
 export suffix="pt2_3"
 
-export spw=False # True or False (skip calculation of weights)
+export spw=True # True or False (skip calculation of weights)
 export smy=False # True or False (skip make yaml)
-export scv=False # True or False (skip cut variation)
-export spm=False # True or False (skip projection for MC)
-export seff=False # True or False (skip efficiency)
-export svn=False # True or False (skip vn extraction)
-export sfcv=False # True or False (skip fraction by cut variation)
-export sddf=False # True or False (skip fraction by data-driven method)
-export sv2vf=False # True or False (skip v2 vs fraction)
+export scv=True # True or False (skip cut variation)
+export spm=True # True or False (skip projection for MC)
+export seff=True # True or False (skip efficiency)
+export svn=True # True or False (skip vn extraction)
+export sfcv=True # True or False (skip fraction by cut variation)
+export sddf=True # True or False (skip fraction by data-driven method)
+export sv2vf=True # True or False (skip v2 vs fraction)
 
 if [ $spw = False ]; then
 	export skip_calc_weights=""

--- a/run3/flow/config_flow.yml
+++ b/run3/flow/config_flow.yml
@@ -67,19 +67,34 @@ eff_filename: 'task_output.root'
 
 # cut variation
 cut_variation:
-       bdt_cut: {
-              bkg: { 
-                     min: [0.1],
-                     max: [0.01],
-                     step: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0., 0., 0., 0., 0.]
-                       },
-              sig: { 
-                     min: [0.05],
-                     max: [0.4],
-                     step: [0.05]
-                       },
-       }
-       # please just make sure that the nCutSets is the same as the number of the min to max+step
+       corr_bdt_cut:
+              bkg_max: [0.001, 0.001, 0.001, 0.001, 0.001, 0.002, 0.002, 0.01, 0.08, 0.1]
+              sig: # the max value is not contained in the range
+                     min: [0.1, 0.2, 0.15, 0.15, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+                     max: [0.92, 0.92, 0.92, 0.92, 0.92, 0.92, 0.92, 0.92, 0.92, 0.92]
+                     step: [0.15, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04]
+       uncorr_bdt_cut:
+            bkg_max: # max probability for bkg, one for each pt bin
+                - [0.001, 0.001, 0.001, 0.008, 0.0006] # pt 1
+                - [0.001, 0.001, 0.001, 0.008, 0.0006] # pt 2
+                - [0.001, 0.001, 0.001, 0.008, 0.0006] # pt 3
+                - [0.001, 0.001, 0.001, 0.008, 0.0006] # pt 4
+                - [0.001, 0.001, 0.001, 0.008, 0.0006] # pt 5
+                - [0.001, 0.001, 0.001, 0.008, 0.0006] # pt 6
+            sig:
+                - min: [0.00, 0.30, 0.45, 0.70, 0.97] # min pt 1
+                  max: [0.30, 0.45, 0.70, 0.97, 1.00] # max pt 1
+                - min: [0.00, 0.30, 0.45, 0.70, 0.97] # min pt 2
+                  max: [0.30, 0.45, 0.70, 0.97, 1.00] # max pt 2
+                - min: [0.00, 0.30, 0.45, 0.70, 0.97] # min pt 3
+                  max: [0.30, 0.45, 0.70, 0.97, 1.00] # max pt 3
+                - min: [0.00, 0.30, 0.45, 0.70, 0.97] # min pt 4
+                  max: [0.30, 0.45, 0.70, 0.97, 1.00] # max pt 4
+                - min: [0.00, 0.30, 0.45, 0.70, 0.97] # min pt 5
+                  max: [0.30, 0.45, 0.70, 0.97, 1.00] # max pt 5
+                - min: [0.00, 0.30, 0.45, 0.70, 0.97] # min pt 6
+                  max: [0.30, 0.45, 0.70, 0.97, 1.00] # max pt 6
+       
 
 # these configurations are available only for the MC
 #_______________________________________________________________________________________________________________________
@@ -117,7 +132,7 @@ shapes:
 #_______________________________________________________________________________________________________________________
 ## used for the MC in projection_thnsparse.py
 ### for D0, D+, Ds
-MC_filename: [/media/wuct/wulby/ALICE/AnRes/D0_flow/pass4/ML/Results/CombPID_noSigCut/AnalysisResults_mc_medium_306505.root]
+MC_filename: [path/to/MCfile.root]
 dirname: hf-task-d0
 sparsenameAll: null
 sparsenamePrompt: hBdtScoreVsMassVsPtVsPtBVsYVsOriginVsD0Type
@@ -125,11 +140,11 @@ sparsenameFD: hBdtScoreVsMassVsPtVsPtBVsYVsOriginVsD0Type
 sparsenameGenPrompt: hSparseAcc # also used in computting pT weights
 sparsenameGenFD: hSparseAcc # also used in computting pT weights
 ### only for D0
-enableRef: true #reflection for D0. 
+enableRef: false #reflection for D0. 
 # if `enableRef` is set to `true`,  and `ReflFile` is empty, then `ReflFile` will be aotumatically filled.
 sparsenameRefl: hBdtScoreVsMassVsPtVsPtBVsYVsOriginVsD0Type
 # if `ReflFile` is filled, then it will use the filled one
-ReflFile: ''
+reflFile: ''
 ### only for Ds
 enableSecPeak: no #no second peak for D+
 sparsenamePromptSecPeak: null
@@ -139,7 +154,7 @@ sparsenameGenFDSecPeak: null
 
 #_______________________________________________________________________________________________________________________
 ## used for compute_frac_cut_var.py 
-histoNameRaw: hRawYieldsTrueSimFit # also ComputeV2vsFDFrac.py
+histoNameRaw: hRawYieldsSimFit # also ComputeV2vsFDFrac.py
 histoNameEffPrompt: hEffPrompt
 histoNameEffFD: hEffFD
 

--- a/run3/flow/get_vn_vs_mass.py
+++ b/run3/flow/get_vn_vs_mass.py
@@ -483,7 +483,7 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
                         cSimFit[iCanv].Modified()
                         cSimFit[iCanv].Update()
                 cSimFit[iPt].cd(2)
-                hVnForFit[iPt].GetYaxis().SetRangeUser(-1, 1)
+                hVnForFit[iPt].GetYaxis().SetRangeUser(-0.2, 0.4)
                 hVnForFit[iPt].GetYaxis().SetTitle(f'#it{{v}}_{{{harmonic}}} ({vn_method})')
                 hVnForFit[iPt].GetXaxis().SetRangeUser(massMin, massMax)
                 hVnForFit[iPt].Draw('E')

--- a/run3/flow/get_vn_vs_mass.py
+++ b/run3/flow/get_vn_vs_mass.py
@@ -55,7 +55,7 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
     if not isinstance(massMaxs, list):
         massMaxs = [massMaxs] * len(ptMins)
     useRefl = fitConfig['enableRef']
-    reflFile = fitConfig['reflFile']
+    reflFile = fitConfig['ReflFile']
 
     # read fit configuration
     if not isinstance(fixSigma, list):

--- a/run3/flow/get_vn_vs_mass.py
+++ b/run3/flow/get_vn_vs_mass.py
@@ -14,8 +14,10 @@ from ROOT import gROOT, gPad, gInterpreter, kBlack, kRed, kAzure, kGray, kOrange
 from flow_analysis_utils import get_centrality_bins, get_vnfitter_results, get_ep_vn, getD0ReflHistos, get_particle_info # pylint: disable=import-error,no-name-in-module
 sys.path.append('../../..')
 sys.path.append('../..')
-gInterpreter.ProcessLine(f'#include "./invmassfitter/InvMassFitter.cxx"')
-gInterpreter.ProcessLine(f'#include "./invmassfitter/VnVsMassFitter.cxx"')
+import os
+script_dir = os.path.dirname(os.path.realpath(__file__))
+gInterpreter.ProcessLine(f'#include "{script_dir}/invmassfitter/InvMassFitter.cxx"')
+gInterpreter.ProcessLine(f'#include "{script_dir}/invmassfitter/VnVsMassFitter.cxx"')
 from ROOT import InvMassFitter, VnVsMassFitter
 from utils.StyleFormatter import SetGlobalStyle, SetObjectStyle, DivideCanvas
 from utils.FitUtils import SingleGaus, DoubleGaus, DoublePeakSingleGaus, DoublePeakDoubleGaus, RebinHisto

--- a/run3/flow/project_thnsparse.py
+++ b/run3/flow/project_thnsparse.py
@@ -61,16 +61,18 @@ def check_anres(config, an_res_file, centrality, resolution,
         sig_ml_cuts = config['sig_ml_cuts']
 
     # load input file
-    infile = ROOT.TFile(an_res_file, 'READ')
-    if wagon_id != '':
-        wagon_id = f'_id{wagon_id}'
-    thnsparse = infile.Get(f'hf-task-flow-charm-hadrons{wagon_id}/hSparseFlowCharm')
-    if not thnsparse:
-        sys.exit(f'\033[91m FATAL: Could not find thnsparse in {an_res_file}\033[0m')
+    thnsparse_list, thnsparse_selcent_list, thnsparse_selcents = [], [], []
+    for file in an_res_file:
+        infile = ROOT.TFile(file, 'READ')
+        if wagon_id != '':
+            wagon_id = f'_id{wagon_id}'
+        thnsparse_list.append(infile.Get(f'hf-task-flow-charm-hadrons{wagon_id}/hSparseFlowCharm'))
+        if not thnsparse_list[-1]:
+            sys.exit(f'\033[91m FATAL: Could not find thnsparse in {an_res_file}\033[0m')
 
     # sanity check of the pt bins
-    bin_edges = [thnsparse.GetAxis(axis_pt).GetBinLowEdge(bin) for bin in range(1, thnsparse.GetAxis(axis_pt).GetNbins() + 1)]
-    bin_edges.append(thnsparse.GetAxis(axis_pt).GetBinUpEdge(thnsparse.GetAxis(axis_pt).GetNbins()))
+    bin_edges = [thnsparse_list[-1].GetAxis(axis_pt).GetBinLowEdge(bin) for bin in range(1, thnsparse_list[-1].GetAxis(axis_pt).GetNbins() + 1)]
+    bin_edges.append(thnsparse_list[-1].GetAxis(axis_pt).GetBinUpEdge(thnsparse_list[-1].GetAxis(axis_pt).GetNbins()))
     if any(pt_min not in bin_edges or pt_max not in bin_edges for pt_min, pt_max in zip(pt_mins, pt_maxs)):
         sys.exit('\033[91m FATAL: Too granular pt bins, pt_min or pt_max not in the bin edges\033[0m')
 
@@ -79,8 +81,9 @@ def check_anres(config, an_res_file, centrality, resolution,
     hist_reso = ROOT.TH1F('hist_reso', 'hist_reso', len(cent_bins) - 1, cent_bins[0], cent_bins[-1])
     cent_min = cent_bins[0]
     cent_max = cent_bins[1]
-    thnsparse_selcent = thnsparse.Clone(f'thnsparse_selcent{cent_min}_{cent_max}')
-    thnsparse_selcent.GetAxis(axis_cent).SetRangeUser(cent_min, cent_max)
+    for thnssparse in thnsparse_list:
+        thnsparse_selcent_list.append(thnssparse.Clone(f'thnsparse_selcent{cent_min}_{cent_max}'))
+        thnsparse_selcent_list[-1].GetAxis(axis_cent).SetRangeUser(cent_min, cent_max)
     hist_reso.SetBinContent(hist_reso.FindBin(cent_min), reso)
     vn_axis = axis_sp if vn_method == 'sp' else axis_deltaphi
     if use_inv_mass_bins:
@@ -90,31 +93,33 @@ def check_anres(config, an_res_file, centrality, resolution,
         # loop over pt bins
         for ipt, (pt_min, pt_max) in enumerate(zip(pt_mins, pt_maxs)):
             outfile.mkdir(f'cent_bins{cent_min}_{cent_max}/pt_bins{pt_min}_{pt_max}')
-            thnsparse_selcent.GetAxis(axis_pt).SetRangeUser(pt_min, pt_max)
-            if use_inv_mass_bins:
-                inv_mass_bins_ipt = []
-                rebin = config['Rebin'][ipt]
-                hmass_dummy = thnsparse_selcent.Projection(axis_mass)
-                hmass_dummy = hmass_dummy.Rebin(rebin, f'hmass_dummy_{ipt}')
-                for ibin in range(1, hmass_dummy.GetNbinsX() + 1):
-                    inv_mass_bins_ipt.append(hmass_dummy.GetBinLowEdge(ibin))
-                    if ibin == hmass_dummy.GetNbinsX():
-                        inv_mass_bins_ipt.append(hmass_dummy.GetBinLowEdge(ibin) + hmass_dummy.GetBinWidth(ibin))
-                del hmass_dummy
-                inv_mass_bins[ipt] = inv_mass_bins_ipt
-            inv_mass_bin = inv_mass_bins[ipt]
-            # apply BDT cuts (TODO: save the bdt score distribution after the cuts in the output file)
-            if apply_btd_cuts:
-                print('\033[93m WARNING: Applying BDT cuts\033[0m')
-                thnsparse_selcent.GetAxis(axis_bdt_bkg).SetRangeUser(0, bkg_ml_cuts[ipt])
-                thnsparse_selcent.GetAxis(axis_bdt_sig).SetRangeUser(sig_ml_cuts[ipt], 1)
-
+            for iThn, thnsparse_selcent in enumerate(thnsparse_selcent_list):
+                thnsparse_selcent.GetAxis(axis_pt).SetRangeUser(pt_min, pt_max)
+                if use_inv_mass_bins:
+                    inv_mass_bins_ipt = []
+                    rebin = config['Rebin'][ipt]
+                    hmass_dummy = thnsparse_selcent.Projection(axis_mass)
+                    hmass_dummy = hmass_dummy.Rebin(rebin, f'hmass_dummy_{ipt}')
+                    for ibin in range(1, hmass_dummy.GetNbinsX() + 1):
+                        inv_mass_bins_ipt.append(hmass_dummy.GetBinLowEdge(ibin))
+                        if ibin == hmass_dummy.GetNbinsX():
+                            inv_mass_bins_ipt.append(hmass_dummy.GetBinLowEdge(ibin) + hmass_dummy.GetBinWidth(ibin))
+                    del hmass_dummy
+                    inv_mass_bins[ipt] = inv_mass_bins_ipt
+                inv_mass_bin = inv_mass_bins[ipt]
+                # apply BDT cuts (TODO: save the bdt score distribution after the cuts in the output file)
+                if apply_btd_cuts:
+                    print('\033[93m WARNING: Applying BDT cuts\033[0m')
+                    thnsparse_selcent.GetAxis(axis_bdt_bkg).SetRangeUser(0, bkg_ml_cuts[ipt])
+                    thnsparse_selcent.GetAxis(axis_bdt_sig).SetRangeUser(sig_ml_cuts[ipt], 1)
+                thnsparse_selcents.append(thnsparse_selcent)
+                    
             # create output histograms
             outfile.cd(f'cent_bins{cent_min}_{cent_max}/pt_bins{pt_min}_{pt_max}')
             # compute vn versus mass
             if vn_method == 'deltaphi':
                 hist_mass_inplane, \
-                hist_mass_outplane = get_invmass_vs_deltaphi(thnsparse_selcent,
+                hist_mass_outplane = get_invmass_vs_deltaphi(thnsparse_selcents,
                                                              axis_deltaphi,
                                                              axis_mass)
                 hist_mass_inplane.SetName(f'hist_mass_inplane_cent{cent_min}_{cent_max}_pt{pt_min}_{pt_max}')
@@ -124,25 +129,31 @@ def check_anres(config, an_res_file, centrality, resolution,
                 hist_mass_inplane.Write()
                 hist_mass_outplane.Write()
             else:
-                hist_vn = get_vn_versus_mass(thnsparse_selcent, inv_mass_bin,
+                hist_vn = get_vn_versus_mass(thnsparse_selcents, inv_mass_bin,
                                              axis_mass, vn_axis, False)
                 hist_vn.SetName(f'hist_vn_{vn_method}_pt{pt_min}_{pt_max}')
                 hist_vn.SetDirectory(0)
                 if reso > 0:
                     hist_vn.Scale(1./reso)
                     hist_vn.Write()
-                hist_mass = thnsparse_selcent.Projection(axis_mass)
-                hist_mass.SetName(f'hist_mass_cent{cent_min}_{cent_max}_pt{pt_min}_{pt_max}')
+                for iThn, thnsparse_selcent in enumerate(thnsparse_selcent_list):
+                    hist_mass_temp = thnsparse_selcent.Projection(axis_mass)
+                    hist_mass_temp.SetName(f'hist_mass_cent{cent_min}_{cent_max}_pt{pt_min}_{pt_max}_{iThn}')
+                    if iThn == 0:
+                        hist_mass = hist_mass_temp.Clone(f'hist_mass_cent{cent_min}_{cent_max}_pt{pt_min}_{pt_max}')
+                        hist_mass.SetDirectory(0)
+                        hist_mass.Reset()
+                    hist_mass.Add(hist_mass_temp)
                 hist_mass.Write()
             
             if config['axes'].get('occupancy'):
-                hist_occ = get_occupancy(thnsparse_selcent, config['axes']['occupancy'], False)
+                hist_occ = get_occupancy(thnsparse_selcents, config['axes']['occupancy'], False)
                 hist_occ.SetName(f'hist_occ_pt{pt_min}_{pt_max}')
                 hist_occ.SetDirectory(0)
                 hist_occ.Write()
 
             if config['axes'].get('evselbits'):
-                hist_evselbits = get_evselbits(thnsparse_selcent, config['axes']['evselbits'], False)
+                hist_evselbits = get_evselbits(thnsparse_selcents, config['axes']['evselbits'], False)
                 hist_evselbits.SetName(f'hist_evselbits_pt{pt_min}_{pt_max}')
                 hist_evselbits.SetDirectory(0)
                 hist_evselbits.Write()
@@ -160,8 +171,10 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Arguments")
     parser.add_argument("config", metavar="text",
                         default="config.yaml", help="configuration file")
-    parser.add_argument("an_res_file", metavar="text",
-                        default="an_res.root", help="input ROOT file with anres")
+    # parser.add_argument("an_res_file", metavar="text",
+    #                     default="an_res.root", help="input ROOT file with anres")
+    parser.add_argument('an_res_file', metavar='text', 
+                        nargs='+', help='input ROOT files with anres')
     parser.add_argument("--centrality", "-c", metavar="text",
                         default="k3050", help="centrality class")
     parser.add_argument("--resolution", "-r",  default=1.,

--- a/run3/flow/run_full_flow_analysis.py
+++ b/run3/flow/run_full_flow_analysis.py
@@ -64,6 +64,7 @@ def run_full_analysis(config,
         print(f"\033[92m Creating output directory {outputdir}\033[0m")
         os.makedirs(outputdir)
 
+    script_dir = os.path.dirname(os.path.realpath(__file__))
 
     if resolution and not skip_resolution:
         # warning
@@ -74,7 +75,7 @@ def run_full_analysis(config,
         if not os.path.exists(f"{outputdir}/resolution"):
             os.makedirs(f"{outputdir}/resolution")
         outputdir_reso = f"-o {outputdir}/resolution/"
-        command_reso = f"python3 compute_reso.py {an_res_file} {cent_withopt} {suffix_withopt} {outputdir_reso} {vn_method_withopt}"
+        command_reso = f"python3 {os.path.join(script_dir, 'compute_reso.py')} {an_res_file} {cent_withopt} {suffix_withopt} {outputdir_reso} {vn_method_withopt}"
         if wagon_id != "":
             command_reso += f" {wagon_id_withopt}"
         print("\n\033[92m Starting resolution extraction\033[0m")
@@ -95,7 +96,7 @@ def run_full_analysis(config,
         reso_file_withopt = f" -r {reso_file}"
         outputdir_proj = f"-o {outputdir}/proj"
         an_res_files = " ".join(an_res_file)
-        command_proj = f"python3 project_thnsparse.py {config} {an_res_files} {cent_withopt} {reso_file_withopt} {suffix_withopt} {outputdir_proj} {vn_method_withopt}"
+        command_proj = f"python3 {os.path.join(script_dir, 'project_thnsparse.py')} {config} {an_res_files} {cent_withopt} {reso_file_withopt} {suffix_withopt} {outputdir_proj} {vn_method_withopt}"
         if wagon_id != "":
             command_proj += f" {wagon_id_withopt}"
         print("\n\033[92m Starting projection\033[0m")
@@ -110,9 +111,9 @@ def run_full_analysis(config,
         proj_file = f"{outputdir}/proj/"
         proj_file += f"proj{suffix}.root"
         if not batch:
-            command_vn = f"python3 get_vn_vs_mass.py {config} {centrality} {proj_file} {outputdir_rawyield} {suffix_withopt} {vn_method_withopt}"
+            command_vn = f"python3 {os.path.join(script_dir, 'get_vn_vs_mass.py')} {config} {centrality} {proj_file} {outputdir_rawyield} {suffix_withopt} {vn_method_withopt}"
         else:
-            command_vn = f"python3 get_vn_vs_mass.py {config} {centrality} {proj_file} {outputdir_rawyield} {suffix_withopt} {vn_method_withopt} --batch"
+            command_vn = f"python3 {os.path.join(script_dir, 'get_vn_vs_mass.py')} {config} {centrality} {proj_file} {outputdir_rawyield} {suffix_withopt} {vn_method_withopt} --batch"
         print("\n\033[92m Starting vn extraction\033[0m")
         print(f"\033[92m {command_vn}\033[0m")
         os.system(command_vn)
@@ -127,7 +128,7 @@ def run_full_analysis(config,
         if not os.path.exists(f"{outputdir}/eff"):
             os.makedirs(f"{outputdir}/eff")
         outputdir_eff = f"-o {outputdir}/eff"
-        command_eff = f"python3 compute_efficiency.py {config} {outputdir_eff} {suffix_withopt}"
+        command_eff = f"python3 {os.path.join(script_dir, 'compute_efficiency.py')} {config} {outputdir_eff} {suffix_withopt}"
         print("\n\033[92m Starting efficiency estimation\033[0m")
         print(f"\033[92m {command_eff}\033[0m")
         os.system(command_eff)
@@ -138,8 +139,6 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Arguments")
     parser.add_argument("config", metavar="text",
                         default="config.yaml", help="configuration file")
-    # parser.add_argument("an_res_file", metavar="text",
-    #                     default="an_res.root", help="input ROOT file with anres")
     parser.add_argument('an_res_file', metavar='text', 
                     nargs='+', help='input ROOT files with anres')
     parser.add_argument("--centrality", "-c", metavar="text",

--- a/run3/flow/run_full_flow_analysis.py
+++ b/run3/flow/run_full_flow_analysis.py
@@ -94,7 +94,8 @@ def run_full_analysis(config,
             reso_file = 1.
         reso_file_withopt = f" -r {reso_file}"
         outputdir_proj = f"-o {outputdir}/proj"
-        command_proj = f"python3 project_thnsparse.py {config} {an_res_file} {cent_withopt} {reso_file_withopt} {suffix_withopt} {outputdir_proj} {vn_method_withopt}"
+        an_res_files = " ".join(an_res_file)
+        command_proj = f"python3 project_thnsparse.py {config} {an_res_files} {cent_withopt} {reso_file_withopt} {suffix_withopt} {outputdir_proj} {vn_method_withopt}"
         if wagon_id != "":
             command_proj += f" {wagon_id_withopt}"
         print("\n\033[92m Starting projection\033[0m")
@@ -137,8 +138,10 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Arguments")
     parser.add_argument("config", metavar="text",
                         default="config.yaml", help="configuration file")
-    parser.add_argument("an_res_file", metavar="text",
-                        default="an_res.root", help="input ROOT file with anres")
+    # parser.add_argument("an_res_file", metavar="text",
+    #                     default="an_res.root", help="input ROOT file with anres")
+    parser.add_argument('an_res_file', metavar='text', 
+                    nargs='+', help='input ROOT files with anres')
     parser.add_argument("--centrality", "-c", metavar="text",
                         default="k3050", help="centrality class")
     parser.add_argument("--resolution", "-r",  default="",

--- a/run3/tool/config_pre.yml
+++ b/run3/tool/config_pre.yml
@@ -1,0 +1,96 @@
+# ______________________________________________________________________________________________________________________________________________________
+# ptmins: [0,1,  1.5,2,  2.5,3,  3.5,4,5,6,7,8,9 ,10,12,16,24,36] 
+# ptmaxs: [1,1.5,2,  2.5,3,  3.5,4,  5,6,7,8,9,10,12,16,24,36,50]
+
+ptmins: [1, 2, 2.5, 3, 3.5, 4, 5, 6, 7, 8, 10, 12, 16] #, 24, 36] #, 36] #14
+ptmaxs: [2, 2.5, 3, 3.5, 4, 5, 6, 7, 8, 10, 12, 16, 24] #, 36, 50] #, 50]
+
+# axes config
+    # 'Mass': 0,
+    # 'Pt': 1,
+    # 'cent': 2,
+    # 'sp': 3,
+    # 'score_bkg': 4,
+    # 'score_FD': 5,
+    # 'occ': 6
+
+axestokeep: [0, 1, 2, 3, 4, 5]
+outputDir: '/home/wuct/ALICE/local/Results/BDT/full'
+
+config_flow: '/home/wuct/ALICE/local/DmesonAnalysis/run3/flow/Results/2060/k3050/large/sp/config/config_flow_3050l_full.yml'
+centrality: 'k3050'
+resolution: '/media/wuct/wulby/ALICE/AnRes/resolution/output_reso/resospk3050_inte.root'
+
+#______________________________________________________________________________________________________________________________________________________
+# used for the fit
+# global info (do not change)
+axes: {mass: 0,
+       pt: 1,
+       cent: 2,
+       sp: 3,
+       deltaphi: 3,
+       bdt_bkg: 4,
+       bdt_sig: 5}
+
+harmonic: 2 # 2: v2, 3: v3, etc.
+
+# inv_mass_bins (one for each pt bin)
+inv_mass_bins: [ #[1.72,1.76,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.02,2.06], #1
+                [1.72,1.74,1.76,1.78,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.00,2.02,2.04,2.06],
+                [1.72,1.74,1.76,1.78,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.00,2.02,2.04,2.06], #1
+                [1.72,1.74,1.76,1.78,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.00,2.02,2.04,2.06], #2
+                [1.70,1.72,1.74,1.76,1.78,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.00,2.02,2.04,2.06], #3
+                [1.70,1.72,1.74,1.76,1.78,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.00,2.02,2.04,2.06], #4
+                [1.72,1.76,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.02,2.06], #5
+                [1.72,1.76,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.02,2.06], #6
+                #[1.72,1.76,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.02,2.06], #7
+                [1.72,1.76,1.80,1.82,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.02,2.06],
+                [1.72,1.76,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.02,2.06],
+                [1.72,1.76,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.02,2.06],
+                [1.68,1.72,1.76,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.02,2.06],
+                [1.66,1.70,1.74,1.78,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.92,1.94,1.96,2.0,2.04,2.08],
+                [1.66,1.70,1.74,1.78,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.92,1.94,1.96,2.0,2.04,2.08],]
+use_inv_mass_bins: false # use binning in invariant mass distribution, neglects inv_mass_bins (default: false)
+
+apply_btd_cuts: True # apply bdt cuts
+bkg_ml_cuts: [0.0008, 0.0008, 0.0008, 0.0008, 0.0008, 0.001, 0.001, 0.001, 0.002, 0.003, 0.005, 0.008, 0.008] # max probability for bkg, one for each pt bin
+sig_ml_cuts: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]       # min probability for sig, one for each pt bin
+
+# ep/sp subevents
+detA: 'FT0c'
+detB: 'FV0a'
+detC: 'TPCtot'
+
+# fit options
+Dmeson: 'Dzero'
+FixSigma: 0
+Sigma: [0.018, 0.018, 0.020, 0.022, 0.024, 0.026, 0.028, 0.032, 0.032, 0.035, 0.040, 0.045, 0.05, 0.022]
+SigmaFile: ''
+SigmaMultFactor: 1.
+FixMean: 0
+MeanFile: ''
+       #    1-2  2-2.5  2.5-3  3-3.5  3.5-4  4-5   5-6   6-7   7-8   8-10  10-12  12-16  16-24  24-36
+NSigma4SB: [4,   4,     4,     4,     4,     4,    4,    4,    4,    4,    3,     3,     3,     3,     3,    3, 3, 3, 3, 3]
+MassMin: [ 1.72, 1.72,  1.72,  1.72,  1.72,  1.72, 1.72, 1.72, 1.72, 1.72, 1.68,  1.66,  1.66,  1.72,  1.68, 1.72, 1.70 ] 
+MassMax: [ 2.02, 2.02,  2.02,  2.02,  2.02,  2.02, 2.04, 2.04, 2.06, 2.06, 2.06,  2.08,  2.08,  2.06,  2.06, 2.00, 2.00, 2.00, 2.05, 2.00, 2.00, 2.00, 2.00 ]
+Rebin: [   4,    4,     4,     4,     4,     4,    4,    4,    4,    4,    8,     8,     8,     4,     6, 6, 6, 10, 10, 5, 5, 10, 5, 5]
+InclSecPeak: [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
+SigmaSecPeak: []
+SigmaFileSecPeak: ''
+SigmaMultFactorSecPeak: 1.
+FixSigmaToFirstPeak: 0
+UseLikelihood: 1
+BkgFunc: [ 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo' ]
+SgnFunc: [ 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus' ]
+BkgFuncVn: ['kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin' ]
+# only for D0
+# if `enableRef` is set to `true`,  and `ReflFile` is empty, then `ReflFile` will be aotumatically filled.
+enableRef: false #reflection for D0. 
+# if `ReflFile` is filled, then it will use the filled one
+reflFile: ''
+ReflFunc: "2gaus"
+FixSigmaRatio: 0 # used only if SgnFunc = k2GausSigmaRatioPar
+SigmaRatioFile: ""
+BoundMean: 0 # 0: Do not set limits on mean range, 1: the mean is set to be between MassMin[i] and MassMax[i]
+enableRef: false #reflection for D0. 
+ReflFile: ''

--- a/run3/tool/pre_process.py
+++ b/run3/tool/pre_process.py
@@ -1,0 +1,148 @@
+'''
+This sricpt is used to pre-process a/multi large AnRes.root for the BDT training:
+    - split the input by pT
+    - obtain the sigma from prompt enhance sample
+python3 pre_process.py config_pre.yml AnRes_1.root AnRes_2.root --pre --sigma  
+'''
+import os
+import sys
+import yaml
+import array
+import ROOT
+import argparse
+import concurrent.futures
+
+def cook_thnsparse(thnsparse_list, ptmins, ptmaxs, axestokeep):
+    '''
+    Split the input THnSparse by pT bins and project onto axes to keep.
+
+    Input:
+        - thnsparse_list (list): List of input THnSparse objects.
+        - ptmins (list): List of minimum pT values for each bin.
+        - ptmaxs (list): List of maximum pT values for each bin.
+        - axestokeep (list): List of axes to keep in the projection.
+
+    Returns:
+        - dict: Dictionary of projected THnSparse objects for each pT bin.
+    '''
+    thnsparses = {}
+    for iThn, thnsparse in enumerate(thnsparse_list):
+        for iPt in range(0, len(ptmins)):
+            binMin = thnsparse.GetAxis(1).FindBin(ptmins[iPt]*1.00001)
+            binMax = thnsparse.GetAxis(1).FindBin(ptmaxs[iPt]*0.99999)
+            thnsparse.GetAxis(1).SetRange(binMin, binMax)
+            thn_proj = thnsparse.Projection(len(axestokeep), array.array('i', axestokeep), 'O')
+            
+            if iThn == 0:
+                thnsparses[iPt] = thn_proj
+            else:
+                thnsparses[iPt].Add(thn_proj)
+    return thnsparses
+
+def pre_process(an_res_file, ptmins, ptmaxs, axestokeep, outputDir):
+    
+    # Load the ThnSparse
+    thnsparse_list = []
+    for file in an_res_file:
+        infile = ROOT.TFile(file, 'READ')
+        thnsparse_list.append(infile.Get('hf-task-flow-charm-hadrons/hSparseFlowCharm'))
+        print(infile.GetName())
+
+    def process_pt_bin(iPt, ptmin, ptmax, thnsparse_list, axestokeep, outputDir):
+        pre_thnsparse = None
+        # add posibility to apply cuts for different variables
+        for iThn, thnsparse in enumerate(thnsparse_list):
+            binMin = thnsparse.GetAxis(1).FindBin(ptmin * 1.00001)
+            binMax = thnsparse.GetAxis(1).FindBin(ptmax * 0.99999)
+            thnsparse.GetAxis(1).SetRange(binMin, binMax)
+            
+            thn_proj = thnsparse.Projection(len(axestokeep), array.array('i', axestokeep), 'O')
+            thn_proj.SetName(thnsparse.GetName())
+            
+            if iThn == 0:
+                pre_thnsparse = thn_proj.Clone()
+            else:
+                pre_thnsparse.Add(thn_proj)
+        
+        os.makedirs(f'{outputDir}/pre/AnRes', exist_ok=True)
+        outFile = ROOT.TFile(f'{outputDir}/pre/AnRes/AnalysisResults_pt{iPt}.root', 'RECREATE')
+        outFile.mkdir('hf-task-flow-charm-hadrons')
+        outFile.cd('hf-task-flow-charm-hadrons')
+        pre_thnsparse.Write()
+        outFile.Close()
+        
+        del pre_thnsparse
+        
+        print(f'Finished processing pT bin {ptmin} - {ptmax}')
+
+    # Loop over each pt bin in parallel
+    max_workers = 6
+    with concurrent.futures.ThreadPoolExecutor(max_workers) as executor:
+        tasks = [executor.submit(process_pt_bin, iPt, ptmin, ptmax, thnsparse_list, axestokeep, outputDir) for iPt, (ptmin, ptmax) in enumerate(zip(ptmins, ptmaxs))]
+        for task in concurrent.futures.as_completed(tasks):
+            task.result()
+        
+def get_sigma(preFiles, config_pre, centrality, resolution, outputDir, skip_projection=False):
+    with open(config_pre, 'r') as cfgPre:
+        config = yaml.safe_load(cfgPre)
+
+    apply_btd_cuts = config['apply_btd_cuts']    
+    
+    if not apply_btd_cuts:
+        print("Warning: 'apply_btd_cuts' is not enabled in the config_pre.")
+    
+    if not skip_projection:
+        skip_proj = ''
+    else:
+        skip_proj = '--skip_projection'
+    
+    os.makedirs(f'{outputDir}/pre/sigma', exist_ok=True)
+
+    str_preFiles = ' '.join(preFiles)
+    command = (f"python3 ../flow/run_full_flow_analysis.py {config_pre} {str_preFiles} \
+                -c {centrality} -o {outputDir}/pre/sigma \
+                -s sigma -v sp --r {resolution} \
+                --skip_efficiency --skip_resolution \
+                {skip_proj}")
+    os.system(f'{command}')
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Arguments")
+    parser.add_argument('config_pre', metavar='text', 
+                        default='config_pre.yml', help='configuration file')
+    parser.add_argument('an_res_file', metavar='text', 
+                        nargs='+', help='input ROOT files with anres')
+    parser.add_argument('--pre', action='store_true', help='pre-process the AnRes.root')
+    parser.add_argument('--sigma', action='store_true', help='get the sigma')
+    parser.add_argument('--skip_projection', '-sp', action='store_true', help='skip the projection')
+    args = parser.parse_args()
+
+    if not args.pre and not args.sigma:
+        print('Please specify the action to perform.')
+        sys.exit(1)
+
+    with open(args.config_pre, 'r') as cfgPre:
+        config = yaml.safe_load(cfgPre)
+  
+    # Load the configuration
+    ptmins = config['ptmins']
+    ptmaxs = config['ptmaxs']
+    axestokeep = config['axestokeep']
+    outputDir = config['outputDir']
+    
+    if args.pre:
+        pre_process(args.an_res_file, ptmins, ptmaxs, axestokeep, outputDir)
+    
+    if args.sigma:
+        
+        centrality = config['centrality']
+        resolution = config['resolution']
+        
+        if os.path.exists(f'{outputDir}/pre'):
+            preFiles = [f'{outputDir}/pre/AnRes/AnalysisResults_pt{iFile}.root' for iFile in range(len(ptmins))]
+        else:
+            raise ValueError(f'No eff fodel found in {outputDir}')
+        preFiles.sort()
+        
+        # you have to know the sigma from the differet prompt enhance samples is stable first
+        get_sigma(preFiles, args.config_pre, centrality, resolution, outputDir, skip_projection=args.skip_projection)


### PR DESCRIPTION
- Pre-process, including splitting the AnaRes.root by pt, and obtaining the sigma from prompt enhanced samples
- Optimize the logic of get_cut_sets, including correlated cut and uncorrelated cut
- Considered processing different ncutset for each pt bins (this will cause some duplicate cutset was run)